### PR TITLE
Fix python 2 error: No module named builtins

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+0.2.1
+==================
+* Fixed Python 2 error: No module named builtins
+
 0.2.0 (2018-06-04)
 ==================
 * Added python 3 compatibility

--- a/epubbuilder/epub.py
+++ b/epubbuilder/epub.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from builtins import str
-
 # Copyright (c) 2012, Bin Tan
 # This file is distributed under the BSD Licence.
 # See python-epub-builder-license.txt for details.

--- a/epubbuilder/tests/__init__.py
+++ b/epubbuilder/tests/__init__.py
@@ -1,7 +1,5 @@
 from __future__ import unicode_literals
 
-from builtins import str
-
 from epubbuilder import epub
 from unittest import TestCase
 import os.path


### PR DESCRIPTION
`str()` is available on current versions of python 2 and 3, so I'm not
sure why this import was needed. It's making python 2 fail:

  https://travis-ci.org/ccnmtl/worth2/jobs/469328781